### PR TITLE
Fix snap points

### DIFF
--- a/.changeset/soft-peas-deliver.md
+++ b/.changeset/soft-peas-deliver.md
@@ -1,0 +1,5 @@
+---
+"vaul-vue": patch
+---
+
+Fix snap points

--- a/.changeset/sweet-crabs-cough.md
+++ b/.changeset/sweet-crabs-cough.md
@@ -1,0 +1,5 @@
+---
+"vaul-vue": patch
+---
+
+adjust snapPoints on window resize

--- a/.changeset/sweet-crabs-cough.md
+++ b/.changeset/sweet-crabs-cough.md
@@ -2,4 +2,4 @@
 "vaul-vue": patch
 ---
 
-adjust snapPoints on window resize
+fix snap points handling

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm build:package
       - run: npx playwright install --with-deps
       - run: pnpm test || exit 1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/packages/vaul-vue/src/useSnapPoints.ts
+++ b/packages/vaul-vue/src/useSnapPoints.ts
@@ -163,14 +163,14 @@ export function useSnapPoints({
     velocity: number
     dismissible: boolean
   }) {
-    if (fadeFromIndex === undefined)
+    if (fadeFromIndex.value === undefined)
       return
 
     const currentPosition
     = direction.value === 'bottom' || direction.value === 'right'
       ? (activeSnapPointOffset.value ?? 0) - draggedDistance
       : (activeSnapPointOffset.value ?? 0) + draggedDistance
-    const isOverlaySnapPoint = activeSnapPointIndex.value === (fadeFromIndex.value ?? 0) - 1
+    const isOverlaySnapPoint = activeSnapPointIndex.value === fadeFromIndex.value - 1
     const isFirst = activeSnapPointIndex.value === 0
     const hasDraggedUp = draggedDistance > 0
 
@@ -228,8 +228,8 @@ export function useSnapPoints({
       return
     const newValue
     = direction.value === 'bottom' || direction.value === 'right'
-      ? (activeSnapPointOffset.value ?? 0) - draggedDistance
-      : (activeSnapPointOffset.value ?? 0) + draggedDistance
+      ? activeSnapPointOffset.value - draggedDistance
+      : activeSnapPointOffset.value + draggedDistance
 
     // Don't do anything if we exceed the last(biggest) snap point
     if ((direction.value === 'bottom' || direction.value === 'right') && newValue < snapPointsOffset.value[snapPointsOffset.value.length - 1])
@@ -245,16 +245,16 @@ export function useSnapPoints({
 
   function getPercentageDragged(absDraggedDistance: number, isDraggingDown: boolean) {
     if (
-      !snapPoints
+      !snapPoints.value
       || typeof activeSnapPointIndex.value !== 'number'
       || !snapPointsOffset.value
-      || fadeFromIndex === undefined
+      || fadeFromIndex.value === undefined
     )
       return null
 
     // If this is true we are dragging to a snap point that is supposed to have an overlay
-    const isOverlaySnapPoint = activeSnapPointIndex.value === (fadeFromIndex.value ?? 0) - 1
-    const isOverlaySnapPointOrHigher = activeSnapPointIndex.value >= (fadeFromIndex.value ?? 0)
+    const isOverlaySnapPoint = activeSnapPointIndex.value === fadeFromIndex.value - 1
+    const isOverlaySnapPointOrHigher = activeSnapPointIndex.value >= fadeFromIndex.value
 
     if (isOverlaySnapPointOrHigher && isDraggingDown)
       return 0

--- a/packages/vaul-vue/src/useSnapPoints.ts
+++ b/packages/vaul-vue/src/useSnapPoints.ts
@@ -1,4 +1,4 @@
-import { type ComponentPublicInstance, type Ref, computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { type ComponentPublicInstance, type Ref, computed, nextTick, watch } from 'vue'
 import { isVertical, set } from './helpers'
 import { TRANSITIONS, VELOCITY_THRESHOLD } from './constants'
 import type { DrawerDirection } from './types'
@@ -22,30 +22,6 @@ export function useSnapPoints({
   onSnapPointChange,
   direction,
 }: useSnapPointsProps) {
-  const windowDimensions = ref(typeof window !== 'undefined'
-    ? {
-        innerWidth: window.innerWidth,
-        innerHeight: window.innerHeight,
-      }
-    : undefined)
-
-  function onResize() {
-    windowDimensions.value = {
-      innerWidth: window.innerWidth,
-      innerHeight: window.innerHeight,
-    }
-  }
-
-  onMounted(() => {
-    if (typeof window !== 'undefined')
-      window.addEventListener('resize', onResize)
-  })
-
-  onBeforeUnmount(() => {
-    if (typeof window !== 'undefined')
-      window.removeEventListener('resize', onResize)
-  })
-
   const isLastSnapPoint = computed(
     () =>
       (snapPoints.value
@@ -70,6 +46,7 @@ export function useSnapPoints({
   const snapPointsOffset = computed(
     () =>
       snapPoints.value?.map((snapPoint) => {
+        const hasWindow = typeof window !== 'undefined'
         const isPx = typeof snapPoint === 'string'
         let snapPointAsNumber = 0
 
@@ -77,17 +54,17 @@ export function useSnapPoints({
           snapPointAsNumber = Number.parseInt(snapPoint, 10)
 
         if (isVertical(direction.value)) {
-          const height = isPx ? snapPointAsNumber : windowDimensions.value ? snapPoint * windowDimensions.value.innerHeight : 0
+          const height = isPx ? snapPointAsNumber : hasWindow ? snapPoint * window.innerHeight : 0
 
-          if (windowDimensions.value)
-            return direction.value === 'bottom' ? windowDimensions.value.innerHeight - height : -windowDimensions.value.innerHeight + height
+          if (hasWindow)
+            return direction.value === 'bottom' ? window.innerHeight - height : -window.innerHeight + height
 
           return height
         }
-        const width = isPx ? snapPointAsNumber : windowDimensions.value ? snapPoint * windowDimensions.value.innerWidth : 0
+        const width = isPx ? snapPointAsNumber : hasWindow ? snapPoint * window.innerWidth : 0
 
-        if (windowDimensions.value)
-          return direction.value === 'right' ? windowDimensions.value.innerWidth - width : -windowDimensions.value.innerWidth + width
+        if (hasWindow)
+          return direction.value === 'right' ? window.innerWidth - width : -window.innerWidth + width
 
         return width
       }) ?? [],

--- a/packages/vaul-vue/src/useSnapPoints.ts
+++ b/packages/vaul-vue/src/useSnapPoints.ts
@@ -1,4 +1,4 @@
-import { type ComponentPublicInstance, type Ref, computed, nextTick, watch } from 'vue'
+import { type ComponentPublicInstance, type Ref, computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { isVertical, set } from './helpers'
 import { TRANSITIONS, VELOCITY_THRESHOLD } from './constants'
 import type { DrawerDirection } from './types'
@@ -22,6 +22,30 @@ export function useSnapPoints({
   onSnapPointChange,
   direction,
 }: useSnapPointsProps) {
+  const windowDimensions = ref(typeof window !== 'undefined'
+    ? {
+        innerWidth: window.innerWidth,
+        innerHeight: window.innerHeight,
+      }
+    : undefined)
+
+  function onResize() {
+    windowDimensions.value = {
+      innerWidth: window.innerWidth,
+      innerHeight: window.innerHeight,
+    }
+  }
+
+  onMounted(() => {
+    if (typeof window !== 'undefined')
+      window.addEventListener('resize', onResize)
+  })
+
+  onBeforeUnmount(() => {
+    if (typeof window !== 'undefined')
+      window.removeEventListener('resize', onResize)
+  })
+
   const isLastSnapPoint = computed(
     () =>
       (snapPoints.value
@@ -46,7 +70,6 @@ export function useSnapPoints({
   const snapPointsOffset = computed(
     () =>
       snapPoints.value?.map((snapPoint) => {
-        const hasWindow = typeof window !== 'undefined'
         const isPx = typeof snapPoint === 'string'
         let snapPointAsNumber = 0
 
@@ -54,17 +77,17 @@ export function useSnapPoints({
           snapPointAsNumber = Number.parseInt(snapPoint, 10)
 
         if (isVertical(direction.value)) {
-          const height = isPx ? snapPointAsNumber : hasWindow ? snapPoint * window.innerHeight : 0
+          const height = isPx ? snapPointAsNumber : windowDimensions.value ? snapPoint * windowDimensions.value.innerHeight : 0
 
-          if (hasWindow)
-            return direction.value === 'bottom' ? window.innerHeight - height : -window.innerHeight + height
+          if (windowDimensions.value)
+            return direction.value === 'bottom' ? windowDimensions.value.innerHeight - height : -windowDimensions.value.innerHeight + height
 
           return height
         }
-        const width = isPx ? snapPointAsNumber : hasWindow ? snapPoint * window.innerWidth : 0
+        const width = isPx ? snapPointAsNumber : windowDimensions.value ? snapPoint * windowDimensions.value.innerWidth : 0
 
-        if (hasWindow)
-          return direction.value === 'right' ? window.innerWidth - width : -window.innerWidth + width
+        if (windowDimensions.value)
+          return direction.value === 'right' ? windowDimensions.value.innerWidth - width : -windowDimensions.value.innerWidth + width
 
         return width
       }) ?? [],

--- a/playground/src/views/tests/WithSnapPointsView.vue
+++ b/playground/src/views/tests/WithSnapPointsView.vue
@@ -19,7 +19,7 @@ const open = ref<boolean>(false)
     <div data-testid="active-snap-index">
       {{ activeSnapPointIndex }}
     </div>
-    <DrawerRoot v-model:open="open" :snap-points="snapPoints" :active-snap-point="snap">
+    <DrawerRoot v-model:open="open" v-model:active-snap-point="snap" :snap-points="snapPoints">
       <DrawerTrigger as-child>
         <button data-testid="trigger" class="text-2xl">
           Open Drawer
@@ -97,7 +97,6 @@ const open = ref<boolean>(false)
                 />
               </svg>
             </div>
-            {' '}
             <h1 class="text-2xl mt-2 font-medium">
               The Hidden Details
             </h1>

--- a/playground/src/views/tests/WithSnapPointsView.vue
+++ b/playground/src/views/tests/WithSnapPointsView.vue
@@ -2,13 +2,13 @@
 import { DrawerContent, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'vaul-vue'
 import { computed, ref } from 'vue'
 
-const snapPoints = [0, '148px', '355px', 1]
+const snapPoints = ['148px', '355px', 1]
 
-const snap = ref<number | string | null>(snapPoints[1])
+const snap = ref<number | string | null>(snapPoints[0])
 
 const activeSnapPointIndex = computed(() => snapPoints.indexOf(snap.value as string))
 
-const open = ref<boolean>(true)
+const open = ref<boolean>(false)
 </script>
 
 <template>


### PR DESCRIPTION
closes #63 

This currently fixes some reactivity issues where `.value´ wasn't correctly checked. However the issue from #63 with the snap point not being considered when dragging down is still happening.