### PR TITLE
feat: add support for handle only interaction

### DIFF
--- a/.changeset/famous-lamps-know.md
+++ b/.changeset/famous-lamps-know.md
@@ -1,0 +1,5 @@
+---
+"vaul-vue": patch
+---
+
+add support for handle only interaction

--- a/packages/vaul-vue/src/DrawerContent.vue
+++ b/packages/vaul-vue/src/DrawerContent.vue
@@ -18,6 +18,7 @@ const {
   keyboardIsOpen,
   closeDrawer,
   direction,
+  handleOnly,
 } = injectDrawerRootContext()
 
 const snapPointHeight = computed(() => {
@@ -45,6 +46,20 @@ function handlePointerDownOutside(event: Event) {
   closeDrawer()
 }
 
+function handlePointerDown(event: PointerEvent) {
+  if (handleOnly.value)
+    return
+
+  onPress(event)
+}
+
+function handleOnDrag(event: PointerEvent) {
+  if (handleOnly.value)
+    return
+
+  onDrag(event)
+}
+
 watch(
   isOpen,
   (open) => {
@@ -65,8 +80,8 @@ watch(
     :vaul-drawer-direction="direction"
     :vaul-drawer-visible="isVisible ? 'true' : 'false'"
     :style="{ '--snap-point-height': snapPointHeight }"
-    @pointerdown="onPress"
-    @pointermove="onDrag"
+    @pointerdown="handlePointerDown"
+    @pointermove="handleOnDrag"
     @pointerup="onRelease"
     @pointer-down-outside="handlePointerDownOutside"
     @escape-key-down="(event) => {

--- a/packages/vaul-vue/src/DrawerHandle.vue
+++ b/packages/vaul-vue/src/DrawerHandle.vue
@@ -1,11 +1,78 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { injectDrawerRootContext } from './context'
+import type { DrawerHandleProps } from './controls'
 
-const {
-  onPress,
-  onDrag,
-  handleOnly,
-} = injectDrawerRootContext()
+const props = withDefaults(defineProps<DrawerHandleProps>(), {
+  preventCycle: false,
+})
+
+const LONG_HANDLE_PRESS_TIMEOUT = 250
+const DOUBLE_TAP_TIMEOUT = 120
+
+const { onPress, onDrag, handleRef, handleOnly, isVisible, snapPoints, activeSnapPoint, isDragging, dismissible, closeDrawer }
+    = injectDrawerRootContext()
+
+const closeTimeoutId = ref<number | null>(null)
+const shouldCancelInteraction = ref(false)
+
+function handleStartCycle() {
+  // Stop if this is the second click of a double click
+  if (shouldCancelInteraction.value) {
+    handleCancelInteraction()
+    return
+  }
+
+  window.setTimeout(() => {
+    handleCycleSnapPoints()
+  }, DOUBLE_TAP_TIMEOUT)
+}
+
+function handleCycleSnapPoints() {
+  // Prevent accidental taps while resizing drawer
+  if (isDragging.value || props.preventCycle || shouldCancelInteraction.value) {
+    handleCancelInteraction()
+    return
+  }
+
+  // Make sure to clear the timeout id if the user releases the handle before the cancel timeout
+  handleCancelInteraction()
+
+  if (!snapPoints.value || snapPoints.value.length === 0) {
+    if (!dismissible.value)
+      closeDrawer()
+
+    return
+  }
+
+  const isLastSnapPoint = activeSnapPoint.value === snapPoints.value[snapPoints.value.length - 1]
+
+  if (isLastSnapPoint && dismissible.value) {
+    closeDrawer()
+    return
+  }
+
+  const currentSnapIndex = snapPoints.value.findIndex(point => point === activeSnapPoint.value)
+
+  if (currentSnapIndex === -1)
+    return // activeSnapPoint not found in snapPoints
+
+  activeSnapPoint.value = snapPoints.value[currentSnapIndex + 1]
+}
+
+function handleStartInteraction() {
+  closeTimeoutId.value = window.setTimeout(() => {
+    // Cancel click interaction on a long press
+    shouldCancelInteraction.value = true
+  }, LONG_HANDLE_PRESS_TIMEOUT)
+}
+
+function handleCancelInteraction() {
+  if (closeTimeoutId.value)
+    window.clearTimeout(closeTimeoutId.value)
+
+  shouldCancelInteraction.value = false
+}
 
 function handlePointerDown(event: PointerEvent) {
   if (handleOnly.value)
@@ -15,14 +82,23 @@ function handlePointerDown(event: PointerEvent) {
 function handleOnDrag(event: PointerEvent) {
   if (handleOnly.value)
     onDrag(event)
+  handleStartInteraction()
 }
 </script>
 
 <template>
   <div
+    ref="handleRef"
+    :data-vaul-drawer-visible="isVisible ? 'true' : 'false'"
+    data-vaul-handle=""
+    aria-hidden="true"
+    @click="handleStartCycle"
+    @pointercancel="handleCancelInteraction"
     @pointerdown="handlePointerDown"
     @pointermove="handleOnDrag"
   >
-    <slot />
+    <span data-vaul-handle-hitarea="" aria-hidden="true">
+      <slot />
+    </span>
   </div>
 </template>

--- a/packages/vaul-vue/src/DrawerHandle.vue
+++ b/packages/vaul-vue/src/DrawerHandle.vue
@@ -57,7 +57,9 @@ function handleCycleSnapPoints() {
   if (currentSnapIndex === -1)
     return // activeSnapPoint not found in snapPoints
 
-  activeSnapPoint.value = snapPoints.value[currentSnapIndex + 1]
+  const nextSnapPointIndex = isLastSnapPoint ? 0 : currentSnapIndex + 1
+
+  activeSnapPoint.value = snapPoints.value[nextSnapPointIndex]
 }
 
 function handleStartInteraction() {

--- a/packages/vaul-vue/src/DrawerHandle.vue
+++ b/packages/vaul-vue/src/DrawerHandle.vue
@@ -77,12 +77,12 @@ function handleCancelInteraction() {
 function handlePointerDown(event: PointerEvent) {
   if (handleOnly.value)
     onPress(event)
+  handleStartInteraction()
 }
 
 function handleOnDrag(event: PointerEvent) {
   if (handleOnly.value)
     onDrag(event)
-  handleStartInteraction()
 }
 </script>
 

--- a/packages/vaul-vue/src/DrawerHandle.vue
+++ b/packages/vaul-vue/src/DrawerHandle.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { injectDrawerRootContext } from './context'
+
+const {
+  onPress,
+  onDrag,
+  handleOnly,
+} = injectDrawerRootContext()
+
+function handlePointerDown(event: PointerEvent) {
+  if (handleOnly.value)
+    onPress(event)
+}
+
+function handleOnDrag(event: PointerEvent) {
+  if (handleOnly.value)
+    onDrag(event)
+}
+</script>
+
+<template>
+  <div
+    @pointerdown="handlePointerDown"
+    @pointermove="handleOnDrag"
+  >
+    <slot />
+  </div>
+</template>

--- a/packages/vaul-vue/src/DrawerHandle.vue
+++ b/packages/vaul-vue/src/DrawerHandle.vue
@@ -104,3 +104,32 @@ function handleOnDrag(event: PointerEvent) {
     </span>
   </div>
 </template>
+
+<style>
+[data-vaul-handle] {
+  display: block;
+  position: relative;
+  opacity: .7;
+  background: #e2e2e4;
+  margin-left: auto;
+  margin-right: auto;
+  height: 5px;
+  width: 32px;
+  border-radius: 1rem;
+  touch-action: pan-y;
+}
+
+[data-vaul-handle]:active, [data-vaul-handle]:hover {
+  opacity: 1;
+}
+
+[data-vaul-handle-hitarea] {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%,-50%);
+  width: max(100%, 2.75rem);
+  height: max(100%, 2.75rem);
+  touch-action: inherit;
+}
+</style>

--- a/packages/vaul-vue/src/DrawerRoot.vue
+++ b/packages/vaul-vue/src/DrawerRoot.vue
@@ -25,6 +25,7 @@ const props = withDefaults(defineProps<DrawerRootProps>(), {
   modal: true,
   scrollLockTimeout: SCROLL_LOCK_TIMEOUT,
   direction: 'bottom',
+  handleOnly: false,
 })
 
 const emit = defineEmits<DrawerRootEmits>()

--- a/packages/vaul-vue/src/context.ts
+++ b/packages/vaul-vue/src/context.ts
@@ -36,6 +36,7 @@ export interface DrawerRootContext {
   emitRelease: (open: boolean) => void
   emitOpenChange: (o: boolean) => void
   nested: Ref<boolean>
+  handleOnly: Ref<boolean>
 }
 
 export const [injectDrawerRootContext, provideDrawerRootContext]

--- a/packages/vaul-vue/src/context.ts
+++ b/packages/vaul-vue/src/context.ts
@@ -10,6 +10,7 @@ export interface DrawerRootContext {
   isVisible: Ref<boolean>
   drawerRef: Ref<ComponentPublicInstance | null>
   overlayRef: Ref<ComponentPublicInstance | null>
+  handleRef: Ref<ComponentPublicInstance | null>
   isDragging: Ref<boolean>
   dragStartTime: Ref<Date | null>
   isAllowedToDrag: Ref<boolean>

--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -42,6 +42,7 @@ export type DrawerRootProps = {
   defaultOpen?: boolean
   nested?: boolean
   direction?: DrawerDirection
+  handleOnly?: boolean
 } & (WithFadeFromProps | WithoutFadeFromProps)
 
 export interface UseDrawerProps {
@@ -57,6 +58,7 @@ export interface UseDrawerProps {
   closeThreshold: Ref<number>
   scrollLockTimeout: Ref<number>
   direction: Ref<DrawerDirection>
+  handleOnly: Ref<boolean>
 }
 
 export interface DrawerRootEmits {
@@ -116,6 +118,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     activeSnapPoint,
     fadeFromIndex,
     direction,
+    handleOnly,
   } = props
 
   const isOpen = ref(open.value ?? false)
@@ -699,5 +702,6 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     emitRelease,
     emitOpenChange,
     nested,
+    handleOnly,
   }
 }

--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -97,6 +97,10 @@ export interface Drawer {
   closeDrawer: () => void
 }
 
+export interface DrawerHandleProps {
+  preventCycle?: boolean
+}
+
 function usePropOrDefaultRef<T>(prop: Ref<T | undefined> | undefined, defaultRef: Ref<T>): Ref<T> {
   return prop && !!prop.value ? (prop as Ref<T>) : defaultRef
 }
@@ -150,6 +154,8 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     props.snapPoints,
     ref<(number | string)[] | undefined>(undefined),
   )
+
+  const handleRef = ref<ComponentPublicInstance | null>(null)
 
   // const onCloseProp = ref<(() => void) | undefined>(undefined)
   // const onOpenChangeProp = ref<((open: boolean) => void) | undefined>(undefined)
@@ -678,6 +684,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     drawerRef,
     drawerHeightRef,
     overlayRef,
+    handleRef,
     isDragging,
     dragStartTime,
     isAllowedToDrag,

--- a/packages/vaul-vue/src/index.ts
+++ b/packages/vaul-vue/src/index.ts
@@ -2,6 +2,7 @@ import DrawerRoot from './DrawerRoot.vue'
 import DrawerRootNested from './DrawerRootNested.vue'
 import DrawerOverlay from './DrawerOverlay.vue'
 import DrawerContent from './DrawerContent.vue'
+import DrawerHandle from './DrawerHandle.vue'
 
 export type {
   DrawerRootEmits,
@@ -18,6 +19,7 @@ export {
   DrawerRootNested,
   DrawerOverlay,
   DrawerContent,
+  DrawerHandle,
 }
 
 export {

--- a/playground/e2e/with-handle.spec.ts
+++ b/playground/e2e/with-handle.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+import { ANIMATION_DURATION } from './constants'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/test/with-handle')
+})
+
+test.describe('With handle', () => {
+  test('click should cycle to the next snap point', async ({ page }) => {
+    await page.waitForTimeout(ANIMATION_DURATION)
+
+    await expect(page.getByTestId('content')).toBeVisible()
+    await expect(page.getByTestId('active-snap-index')).toHaveText('0')
+
+    await page.getByTestId('handle').click()
+    await expect(page.getByTestId('active-snap-index')).toHaveText('1')
+  })
+})

--- a/playground/src/components/DemoDrawer.vue
+++ b/playground/src/components/DemoDrawer.vue
@@ -15,9 +15,8 @@ import { DrawerContent, DrawerHandle, DrawerOverlay, DrawerPortal, DrawerRoot, D
         class="bg-gray-100 flex flex-col rounded-t-[10px] h-full mt-24 max-h-[96%] fixed bottom-0 left-0 right-0"
       >
         <div class="p-4 bg-white rounded-t-[10px] flex-1">
-          <DrawerHandle>
-            <div class="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-gray-300 mb-8" />
-          </DrawerHandle>
+          <DrawerHandle data-testid="handle" class="mb-8 mt-2" />
+
           <div class="max-w-md mx-auto">
             <h2 id="radix-:R3emdaH1:" class="font-medium mb-4">
               Drawer for Vue.

--- a/playground/src/components/DemoDrawer.vue
+++ b/playground/src/components/DemoDrawer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DrawerContent, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'vaul-vue'
+import { DrawerContent, DrawerHandle, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'vaul-vue'
 </script>
 
 <template>
@@ -15,7 +15,9 @@ import { DrawerContent, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger }
         class="bg-gray-100 flex flex-col rounded-t-[10px] h-full mt-24 max-h-[96%] fixed bottom-0 left-0 right-0"
       >
         <div class="p-4 bg-white rounded-t-[10px] flex-1">
-          <div class="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-gray-300 mb-8" />
+          <DrawerHandle>
+            <div class="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-gray-300 mb-8" />
+          </DrawerHandle>
           <div class="max-w-md mx-auto">
             <h2 id="radix-:R3emdaH1:" class="font-medium mb-4">
               Drawer for Vue.

--- a/playground/src/router/index.ts
+++ b/playground/src/router/index.ts
@@ -43,6 +43,10 @@ const router = createRouter({
           component: () => import('../views/tests/WithoutScaledBackgroundView.vue'),
         },
         {
+          path: 'with-handle',
+          component: () => import('../views/tests/WithHandleView.vue'),
+        },
+        {
           path: 'with-scaled-background',
           component: () => import('../views/tests/WithScaledBackgroundView.vue'),
         },

--- a/playground/src/views/tests/WithHandleView.vue
+++ b/playground/src/views/tests/WithHandleView.vue
@@ -176,32 +176,3 @@ const activeSnapPointIndex = computed(() => snapPoints.indexOf(snap.value as str
     </DrawerRoot>
   </div>
 </template>
-
-<style scoped>
-[data-vaul-handle] {
-  display: block;
-  position: relative;
-  opacity: .7;
-  background: #e2e2e4;
-  margin-left: auto;
-  margin-right: auto;
-  height: 5px;
-  width: 32px;
-  border-radius: 1rem;
-  touch-action: pan-y;
-}
-
-[data-vaul-handle]:active, [data-vaul-handle]:hover {
-  opacity: 1;
-}
-
-[data-vaul-handle-hitarea] {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%,-50%);
-  width: max(100%, 2.75rem);
-  height: max(100%, 2.75rem);
-  touch-action: inherit;
-}
-</style>

--- a/playground/src/views/tests/WithHandleView.vue
+++ b/playground/src/views/tests/WithHandleView.vue
@@ -20,20 +20,18 @@ const activeSnapPointIndex = computed(() => snapPoints.indexOf(snap.value as str
 </script>
 
 <template>
-  <div
-    class="w-screen h-screen bg-white p-8 flex justify-center items-center"
-  >
+  <div class="w-screen h-screen bg-white p-8 flex justify-center items-center">
     <div data-testid="active-snap-index">
       {{ activeSnapPointIndex }}
     </div>
-    <DrawerRoot v-model:active-snap-point="snap" open :snap-points="snapPoints">
+    <DrawerRoot v-model:active-snap-point="snap" default-open :snap-points="snapPoints">
       <DrawerTrigger as-child>
-        <button data-testid="trigger" class="text-2xl">
+        <button data-testid="trigger">
           Open Drawer
         </button>
       </DrawerTrigger>
+      <DrawerOverlay class="fixed inset-0 bg-black/40" />
       <DrawerPortal>
-        <DrawerOverlay class="fixed inset-0 bg-black/40" />
         <DrawerContent
           data-testid="content"
           class="fixed flex flex-col bg-white border border-gray-200 border-b-none rounded-t-[10px] bottom-0 left-0 right-0 h-full max-h-[97%] mx-[-1px]"
@@ -41,7 +39,7 @@ const activeSnapPointIndex = computed(() => snapPoints.indexOf(snap.value as str
           <DrawerHandle data-testid="handle" class="mb-8 mt-2" />
           <div
             class="flex flex-col max-w-md mx-auto w-full p-4 pt-5"
-            :class="{
+            :class=" {
               'overflow-y-auto': snap === 1,
               'overflow-hidden': snap !== 1,
             }"
@@ -144,7 +142,7 @@ const activeSnapPointIndex = computed(() => snapPoints.indexOf(snap.value as str
               <figure>
                 <blockquote class="font-serif">
                   “I especially loved the hidden details video. That was so useful, learned a lot by just reading it.
-                  Can&rsquo;t wait for more course content!”
+                  Can't wait for more course content!”
                 </blockquote>
                 <figcaption>
                   <span class="text-sm text-gray-600 mt-2 block">Yvonne Ray, Frontend Developer</span>

--- a/playground/src/views/tests/WithHandleView.vue
+++ b/playground/src/views/tests/WithHandleView.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import {
+  DrawerClose,
+  DrawerContent,
+  DrawerHandle,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerRoot,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'vaul-vue'
+
+import { computed, ref } from 'vue'
+
+const snapPoints = ['148px', '355px']
+
+const snap = ref<number | string | null>(snapPoints[0])
+
+const activeSnapPointIndex = computed(() => snapPoints.indexOf(snap.value as string))
+</script>
+
+<template>
+  <div
+    class="w-screen h-screen bg-white p-8 flex justify-center items-center"
+  >
+    <div data-testid="active-snap-index">
+      {{ activeSnapPointIndex }}
+    </div>
+    <DrawerRoot v-model:active-snap-point="snap" open :snap-points="snapPoints">
+      <DrawerTrigger as-child>
+        <button data-testid="trigger" class="text-2xl">
+          Open Drawer
+        </button>
+      </DrawerTrigger>
+      <DrawerPortal>
+        <DrawerOverlay class="fixed inset-0 bg-black/40" />
+        <DrawerContent
+          data-testid="content"
+          class="fixed flex flex-col bg-white border border-gray-200 border-b-none rounded-t-[10px] bottom-0 left-0 right-0 h-full max-h-[97%] mx-[-1px]"
+        >
+          <DrawerHandle data-testid="handle" class="mb-8 mt-2" />
+          <div
+            class="flex flex-col max-w-md mx-auto w-full p-4 pt-5"
+            :class="{
+              'overflow-y-auto': snap === 1,
+              'overflow-hidden': snap !== 1,
+            }"
+          >
+            <div class="flex items-center">
+              <svg
+                class="text-yellow-400 h-5 w-5 flex-shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="text-yellow-400 h-5 w-5 flex-shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="text-yellow-400 h-5 w-5 flex-shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="text-yellow-400 h-5 w-5 flex-shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              <svg
+                class="text-gray-300 h-5 w-5 flex-shrink-0"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </div>
+            <h1 class="text-2xl mt-2 font-medium">
+              The Hidden Details
+            </h1>
+            <p class="text-sm mt-1 text-gray-600 mb-6">
+              2 modules, 27 hours of video
+            </p>
+            <p class="text-gray-600">
+              The world of user interface design is an intricate landscape filled with hidden details and nuance. In
+              this course, you will learn something cool. To the untrained eye, a beautifully designed UI.
+            </p>
+            <button class="bg-black text-gray-50 mt-8 rounded-md h-[48px] flex-shrink-0 font-medium">
+              Buy for $199
+            </button>
+            <div class="mt-12">
+              <h2 class="text-xl font-medium">
+                Module 01. The Details
+              </h2>
+              <div class="space-y-4 mt-4">
+                <div>
+                  <span class="block">Layers of UI</span>
+                  <span class="text-gray-600">A basic introduction to Layers of Design.</span>
+                </div>
+                <div>
+                  <span class="block">Typography</span>
+                  <span class="text-gray-600">The fundamentals of type.</span>
+                </div>
+                <div>
+                  <span class="block">UI Animations</span>
+                  <span class="text-gray-600">Going through the right easings and durations.</span>
+                </div>
+              </div>
+            </div>
+            <div class="mt-12">
+              <figure>
+                <blockquote class="font-serif">
+                  “I especially loved the hidden details video. That was so useful, learned a lot by just reading it.
+                  Can&rsquo;t wait for more course content!”
+                </blockquote>
+                <figcaption>
+                  <span class="text-sm text-gray-600 mt-2 block">Yvonne Ray, Frontend Developer</span>
+                </figcaption>
+              </figure>
+            </div>
+            <div class="mt-12">
+              <h2 class="text-xl font-medium">
+                Module 02. The Process
+              </h2>
+              <div class="space-y-4 mt-4">
+                <div>
+                  <span class="block">Build</span>
+                  <span class="text-gray-600">Create cool components to practice.</span>
+                </div>
+                <div>
+                  <span class="block">User Insight</span>
+                  <span class="text-gray-600">Find out what users think and fine-tune.</span>
+                </div>
+                <div>
+                  <span class="block">Putting it all together</span>
+                  <span class="text-gray-600">Let&apos;s build an app together and apply everything.</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </DrawerContent>
+      </DrawerPortal>
+    </DrawerRoot>
+  </div>
+</template>
+
+<style scoped>
+[data-vaul-handle] {
+  display: block;
+  position: relative;
+  opacity: .7;
+  background: #e2e2e4;
+  margin-left: auto;
+  margin-right: auto;
+  height: 5px;
+  width: 32px;
+  border-radius: 1rem;
+  touch-action: pan-y;
+}
+
+[data-vaul-handle]:active, [data-vaul-handle]:hover {
+  opacity: 1;
+}
+
+[data-vaul-handle-hitarea] {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%,-50%);
+  width: max(100%, 2.75rem);
+  height: max(100%, 2.75rem);
+  touch-action: inherit;
+}
+</style>


### PR DESCRIPTION
Closes: #68 

Add new DrawerHandle component and handleOnly boolean prop to DrawerHandleRoot to limit drawer interactions to the handle.

```vue
<script setup lang="ts">
import { DrawerContent, DrawerHandle, DrawerOverlay, DrawerPortal, DrawerRoot, DrawerTrigger } from 'vaul-vue'
</script>

<template>
  <DrawerRoot should-scale-background handle-only>
    <DrawerTrigger
      class="rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
    >
      Open Drawer
    </DrawerTrigger>
    <DrawerPortal>
      <DrawerOverlay class="fixed bg-black/40 inset-0" />
      <DrawerContent
        class="bg-gray-100 flex flex-col rounded-t-[10px] h-full mt-24 max-h-[96%] fixed bottom-0 left-0 right-0"
      >
        <div class="p-4 bg-white rounded-t-[10px] flex-1">
          <DrawerHandle>
            <div class="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-gray-300 mb-8" />
          </DrawerHandle>
          <div class="max-w-md mx-auto">
            <!-- Drawer content -->
          </div>
        </div>
      </DrawerContent>
    </DrawerPortal>
  </DrawerRoot>
</template>

```