### PR TITLE
fix: prevent unintended blocking of drag between snap points

### DIFF
--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -285,10 +285,10 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
       const isDraggingInDirection = draggedDistance > 0
 
       // Pre condition for disallowing dragging in the close direction.
-      const noCloseSnapPointsPreCondition = snapPoints.value && !dismissible.value && !isDraggingInDirection
+      const noCloseSnapPointsPreCondition = snapPoints.value && !dismissible.value && !isDraggingInDirection && activeSnapPointIndex.value === 0
 
       // Disallow dragging down to close when first snap point is the active one and dismissible prop is set to false.
-      if (noCloseSnapPointsPreCondition && activeSnapPointIndex.value === 0)
+      if (noCloseSnapPointsPreCondition)
         return
 
       // We need to capture last time when drag with scroll was triggered and have a timeout between


### PR DESCRIPTION
Previously, the drawer would incorrectly block dragging from snap point index 1 to 0 when `dismissible="false"`.

Now, dragging between snap point index 1 to 0 works as expected, while closing the drawer from the first snap point remains blocked when `dismissible="false"`.