### PR TITLE
fix: nested drawer displacement direction

### DIFF
--- a/packages/vaul-vue/src/constants.ts
+++ b/packages/vaul-vue/src/constants.ts
@@ -11,7 +11,9 @@ export const SCROLL_LOCK_TIMEOUT = 100
 
 export const BORDER_RADIUS = 8
 
-export const NESTED_DISPLACEMENT = 16
+export const NESTED_DISPLACEMENT_SCALE = 12
+
+export const NESTED_DISPLACEMENT = 22
 
 export const WINDOW_TOP_OFFSET = 26
 

--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -2,7 +2,7 @@ import { computed, onUnmounted, ref, watch, watchEffect } from 'vue'
 import type { ComponentPublicInstance, Ref } from 'vue'
 import { isClient } from '@vueuse/core'
 import { dampenValue, getTranslate, isVertical, reset, set } from './helpers'
-import { BORDER_RADIUS, DRAG_CLASS, NESTED_DISPLACEMENT, TRANSITIONS, VELOCITY_THRESHOLD, WINDOW_TOP_OFFSET } from './constants'
+import { BORDER_RADIUS, DRAG_CLASS, NESTED_DISPLACEMENT, NESTED_DISPLACEMENT_SCALE, TRANSITIONS, VELOCITY_THRESHOLD, WINDOW_TOP_OFFSET } from './constants'
 import { useSnapPoints } from './useSnapPoints'
 import { usePositionFixed } from './usePositionFixed'
 import type { DrawerRootContext } from './context'
@@ -193,6 +193,10 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
   const initialDrawerHeight = ref(0)
   const drawerHeightRef = computed(() => drawerRef.value?.$el.getBoundingClientRect().height || 0)
 
+  const directionMultiplier = computed(() => direction.value === 'bottom' || direction.value === 'right' ? 1 : -1)
+  const vertical = computed(() => isVertical(direction.value))
+  const nestedDisplacement = computed(() => NESTED_DISPLACEMENT * directionMultiplier.value)
+
   const snapPoints = usePropOrDefaultRef(
     props.snapPoints,
     ref<(number | string)[] | undefined>(undefined),
@@ -325,7 +329,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     dragStartTime.value = new Date()
 
     ;(event.target as HTMLElement).setPointerCapture(event.pointerId)
-    pointerStart.value = isVertical(direction.value) ? event.clientY : event.clientX
+    pointerStart.value = vertical.value ? event.clientY : event.clientX
   }
 
   function onDrag(event: PointerEvent) {
@@ -334,9 +338,8 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
 
     // We need to know how much of the drawer has been dragged in percentages so that we can transform background accordingly
     if (isDragging.value) {
-      const directionMultiplier = direction.value === 'bottom' || direction.value === 'right' ? 1 : -1
       const draggedDistance
-        = (pointerStart.value - (isVertical(direction.value) ? event.clientY : event.clientX)) * directionMultiplier
+        = (pointerStart.value - (vertical.value ? event.clientY : event.clientX)) * directionMultiplier.value
       const isDraggingInDirection = draggedDistance > 0
 
       // Pre condition for disallowing dragging in the close direction.
@@ -383,9 +386,9 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
       if (isDraggingInDirection && !snapPoints.value) {
         const dampenedDraggedDistance = dampenValue(draggedDistance)
 
-        const translateValue = Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier
+        const translateValue = Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier.value
         set(drawerRef.value?.$el, {
-          transform: isVertical(direction.value)
+          transform: vertical.value
             ? `translate3d(0, ${translateValue}px, 0)`
             : `translate3d(${translateValue}px, 0, 0)`,
         })
@@ -421,7 +424,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
           wrapper,
           {
             borderRadius: `${borderRadiusValue}px`,
-            transform: isVertical(direction.value)
+            transform: vertical.value
               ? `scale(${scaleValue}) translate3d(0, ${translateValue}px, 0)`
               : `scale(${scaleValue}) translate3d(${translateValue}px, 0, 0)`,
             transition: 'none',
@@ -431,10 +434,10 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
       }
 
       if (!snapPoints.value) {
-        const translateValue = absDraggedDistance * directionMultiplier
+        const translateValue = absDraggedDistance * directionMultiplier.value
 
         set(drawerRef.value?.$el, {
-          transform: isVertical(direction.value)
+          transform: vertical.value
             ? `translate3d(0, ${translateValue}px, 0)`
             : `translate3d(${translateValue}px, 0, 0)`,
         })
@@ -468,7 +471,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
         {
           borderRadius: `${BORDER_RADIUS}px`,
           overflow: 'hidden',
-          ...(isVertical(direction.value)
+          ...(vertical.value
             ? {
                 transform: `scale(${getScale()}) translate3d(0, calc(env(safe-area-inset-top) + 14px), 0)`,
                 transformOrigin: 'top',
@@ -536,7 +539,7 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
       return
 
     const timeTaken = dragEndTime.value.getTime() - dragStartTime.value.getTime()
-    const distMoved = pointerStart.value - (isVertical(direction.value) ? event.clientY : event.clientX)
+    const distMoved = pointerStart.value - (vertical.value ? event.clientY : event.clientX)
     const velocity = Math.abs(distMoved) / timeTaken
 
     if (velocity > 0.05) {
@@ -549,10 +552,8 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     }
 
     if (snapPoints.value) {
-      const directionMultiplier = direction.value === 'bottom' || direction.value === 'right' ? 1 : -1
-
       onReleaseSnapPoints({
-        draggedDistance: distMoved * directionMultiplier,
+        draggedDistance: distMoved * directionMultiplier.value,
         closeDrawer,
         velocity,
         dismissible: dismissible.value,
@@ -597,25 +598,28 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
   }, { immediate: true })
 
   function onNestedOpenChange(o: boolean) {
-    const scale = o ? (window.innerWidth - NESTED_DISPLACEMENT) / window.innerWidth : 1
-    const y = o ? -NESTED_DISPLACEMENT : 0
+    const dim = vertical.value ? window.innerHeight : window.innerWidth
+    const scale = o ? (dim - NESTED_DISPLACEMENT_SCALE) / dim : 1
+    const translate = o ? -1 * nestedDisplacement.value : 0
 
     if (nestedOpenChangeTimer.value)
       window.clearTimeout(nestedOpenChangeTimer.value)
 
     set(drawerRef.value?.$el, {
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
-      transform: `scale(${scale}) translate3d(0, ${y}px, 0)`,
+      transform: vertical.value
+        ? `scale(${scale}) translate3d(0, ${translate}px, 0)`
+        : `scale(${scale}) translate3d(${translate}px, 0, 0)`,
     })
 
     if (!o && drawerRef.value?.$el) {
       nestedOpenChangeTimer.value = window.setTimeout(() => {
-        const translateValue = getTranslate(drawerRef.value?.$el, direction.value)
+        const translate = getTranslate(drawerRef.value?.$el, direction.value)
         set(drawerRef.value?.$el, {
           transition: 'none',
-          transform: isVertical(direction.value)
-            ? `translate3d(0, ${translateValue}px, 0)`
-            : `translate3d(${translateValue}px, 0, 0)`,
+          transform: vertical.value
+            ? `translate3d(0, ${translate}px, 0)`
+            : `translate3d(${translate}px, 0, 0)`,
         })
       }, 500)
     }
@@ -625,13 +629,14 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
     if (percentageDragged < 0)
       return
 
-    const initialDim = isVertical(direction.value) ? window.innerHeight : window.innerWidth
-    const initialScale = (initialDim - NESTED_DISPLACEMENT) / initialDim
+    const initialDim = vertical.value ? window.innerHeight : window.innerWidth
+    const initialScale = (initialDim - NESTED_DISPLACEMENT_SCALE) / initialDim
     const newScale = initialScale + percentageDragged * (1 - initialScale)
-    const newTranslate = -NESTED_DISPLACEMENT + percentageDragged * NESTED_DISPLACEMENT
+    const displacement = nestedDisplacement.value
+    const newTranslate = -1 * displacement + percentageDragged * displacement
 
     set(drawerRef.value?.$el, {
-      transform: isVertical(direction.value)
+      transform: vertical.value
         ? `scale(${newScale}) translate3d(0, ${newTranslate}px, 0)`
         : `scale(${newScale}) translate3d(${newTranslate}px, 0, 0)`,
       transition: 'none',
@@ -639,14 +644,14 @@ export function useDrawer(props: UseDrawerProps & DialogEmitHandlers): DrawerRoo
   }
 
   function onNestedRelease(o: boolean) {
-    const dim = isVertical(direction.value) ? window.innerHeight : window.innerWidth
-    const scale = o ? (dim - NESTED_DISPLACEMENT) / dim : 1
-    const translate = o ? -NESTED_DISPLACEMENT : 0
+    const dim = vertical.value ? window.innerHeight : window.innerWidth
+    const scale = o ? (dim - NESTED_DISPLACEMENT_SCALE) / dim : 1
+    const translate = o ? -1 * nestedDisplacement.value : 0
 
     if (o) {
       set(drawerRef.value?.$el, {
         transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
-        transform: isVertical(direction.value)
+        transform: vertical.value
           ? `scale(${scale}) translate3d(0, ${translate}px, 0)`
           : `scale(${scale}) translate3d(${translate}px, 0, 0)`,
       })

--- a/packages/vaul-vue/src/style.css
+++ b/packages/vaul-vue/src/style.css
@@ -173,13 +173,6 @@
   }
 }
 
-@media (pointer: fine) {
-  [data-vaul-handle-hitarea]: {
-    width: 100%;
-    height: 100%;
-  }
-}
-
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/playground/src/views/tests/NestedDrawerView.vue
+++ b/playground/src/views/tests/NestedDrawerView.vue
@@ -2,6 +2,7 @@
 import {
   DrawerClose,
   DrawerContent,
+  type DrawerDirection,
   DrawerOverlay,
   DrawerPortal,
   DrawerRoot,
@@ -9,14 +10,89 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from 'vaul-vue'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 const open = ref(false)
+const direction = ref<DrawerDirection>('bottom')
+
+const directionShort = computed(() => {
+  switch (direction.value) {
+    case 'top': return 't'
+    case 'bottom': return 'b'
+    case 'left': return 'l'
+    case 'right': return 'r'
+    default: return direction.value satisfies never
+  }
+})
+
+const directionShortOpposite = computed(() => {
+  switch (direction.value) {
+    case 'top': return 'b'
+    case 'bottom': return 't'
+    case 'left': return 'r'
+    case 'right': return 'l'
+    default: return direction.value satisfies never
+  }
+})
+
+const inset = computed(() => {
+  switch (direction.value) {
+    case 'top': return 'top-0 left-0 right-0'
+    case 'bottom': return 'bottom-0 left-0 right-0'
+    case 'left': return 'top-0 bottom-0 left-0'
+    case 'right': return 'top-0 bottom-0 right-0'
+    default: return direction.value satisfies never
+  }
+})
+
+const isVertical = computed(() => direction.value === 'top' || direction.value === 'bottom')
+
+const contentClasses = computed(() => [
+  'bg-zinc-100 flex flex-col fixed overflow-hidden',
+  `rounded-${directionShortOpposite.value}-[10px]`,
+  `m${directionShortOpposite.value}-24`,
+  isVertical.value ? 'w-[100%] h-[96%]' : 'w-[96%] h-[100%]',
+  inset.value,
+])
+
+const handleClasses = computed(() => [
+  'flex-shrink-0 rounded-full bg-zinc-300',
+  isVertical.value ? 'mx-auto w-12 h-1.5' : 'my-auto w-1.5 h-12',
+  `m${directionShort.value}-8`,
+])
+
+const contentInnerClasses = computed(() => {
+  switch (direction.value) {
+    case 'top': return 'flex-col-reverse'
+    case 'bottom': return 'flex-col'
+    case 'left': return 'flex-row-reverse items-center'
+    case 'right': return 'flex-row items-center'
+    default: return direction.value satisfies never
+  }
+})
 </script>
 
 <template>
-  <div class="w-screen h-screen bg-white p-8 flex justify-center items-center" data-vaul-drawer-wrapper="">
-    <DrawerRoot should-scale-background>
+  <div class="w-screen h-screen bg-white p-8 flex flex-col gap-6 justify-center items-center" data-vaul-drawer-wrapper="">
+    <div class="flex gap-2 items-center">
+      <label for="direction">Direction</label>
+      <select id="direction" v-model="direction" class="p-2">
+        <option value="left">
+          Left
+        </option>
+        <option value="right">
+          Right
+        </option>
+        <option value="top">
+          Top
+        </option>
+        <option value="bottom">
+          Bottom
+        </option>
+      </select>
+    </div>
+
+    <DrawerRoot should-scale-background :direction="direction">
       <DrawerTrigger as-child>
         <button data-testid="trigger" class="text-2xl">
           Open Drawer
@@ -26,10 +102,10 @@ const open = ref(false)
         <DrawerOverlay data-testid="overlay" class="fixed inset-0 bg-black/40" />
         <DrawerContent
           data-testid="content"
-          class="bg-zinc-100 flex flex-col rounded-t-[10px] h-[96%] mt-24 fixed bottom-0 left-0 right-0"
+          :class="contentClasses"
         >
-          <div class="p-4 bg-white rounded-t-[10px] flex-1">
-            <div class="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-zinc-300 mb-8" />
+          <div class="p-4 bg-white flex-1 flex" :class="contentInnerClasses">
+            <div :class="handleClasses" />
             <div class="max-w-md mx-auto">
               <DrawerTitle class="font-medium mb-4">
                 Unstyled drawer for Vue.
@@ -38,7 +114,7 @@ const open = ref(false)
                 This component can be used as a replacement for a Dialog on mobile and tablet
                 devices.
               </p>
-              <DrawerRootNested>
+              <DrawerRootNested :direction="direction">
                 <DrawerTrigger as-child>
                   <button data-testid="nested-trigger" class="text-2xl">
                     Open Second Drawer
@@ -48,10 +124,10 @@ const open = ref(false)
                   <DrawerOverlay data-testid="nested-overlay" class="fixed inset-0 bg-black/40" />
                   <DrawerContent
                     data-testid="nested-content"
-                    class="bg-zinc-100 flex flex-col rounded-t-[10px] h-[96%] mt-24 fixed bottom-0 left-0 right-0"
+                    :class="contentClasses"
                   >
-                    <div class="p-4 bg-white rounded-t-[10px] flex-1">
-                      <div class="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-zinc-300 mb-8" />
+                    <div class="p-4 bg-white flex-1 flex" :class="contentInnerClasses">
+                      <div :class="handleClasses" />
                       <div class="max-w-md mx-auto">
                         <DrawerTitle class="font-medium mb-4">
                           Unstyled drawer for Vue.


### PR DESCRIPTION
# Before
When a nested drawer is opened, the scaling and translation of the root drawer is only correct when direction is `bottom`.
[Screencast from 22-03-25 23:16:17.webm](https://github.com/user-attachments/assets/192035aa-f95e-4b84-84d7-eaa5d7999ac6)

Furthermore, there is a jump in the root drawer's position as soon as you start dragging the nested drawer.
[Screencast from 22-03-25 23:20:30.webm](https://github.com/user-attachments/assets/534ed04c-8ff0-4c58-b0e5-e4a94b8dece0)

# After
[Screencast from 22-03-25 23:19:01.webm](https://github.com/user-attachments/assets/27d68472-24ec-48ec-8c57-22b3fe398e79)
No more position jump when starting a nested drawer drag. The root drawer always moves in the correct direction.
