### PR TITLE
Optional type never

### DIFF
--- a/packages/vaul-vue/src/controls.ts
+++ b/packages/vaul-vue/src/controls.ts
@@ -18,7 +18,7 @@ export interface WithoutFadeFromProps {
   /**
    * Index of a `snapPoint` from which the overlay fade should be applied. Defaults to the last snap point.
    */
-  fadeFromIndex?: never
+  fadeFromIndex: never
 }
 
 export type DrawerRootProps = {


### PR DESCRIPTION
The optional prop fadeFromIndex which has type never was overwriting the whole DrawerRootProps type as never, because making it optional was causing TypeScript confusion. The never type assumes that the prop should never exist, but making it never allows it to be either that or undefined.
